### PR TITLE
Allow autoload.json in arbitrary directories, do not require root namespace in path/allow arbitrary path per root namespace.

### DIFF
--- a/module/Library.php
+++ b/module/Library.php
@@ -1,29 +1,30 @@
 <?php
+
 namespace Axel\Module;
+
 class Library implements \Autoload\Module {
 	private $libraryDir;
 	private $axel;
 	private $rootNs;
 	private $cwd;
-		
+
 	public function __construct(\Axel\Axel $axel, $libraryDir, $rootNs = null, $baseDir = null) {
 		$this->axel = $axel;
 		$this->cwd = is_null($baseDir) ? getcwd() : $baseDir;
-		$this->libraryDir = $this->cwd . DIRECTORY_SEPARATOR . str_replace('./', '', $libraryDir);
+		$this->libraryDir = $this->cwd . DIRECTORY_SEPARATOR . ltrim(str_replace('./', '', $libraryDir), '/\\');
 		$this->rootNs = $rootNs;
 	}
-	
+
 	public function locate($className) {
 
-		$rootNs = is_null($this->rootNs) ? strtolower(explode('\\', rtrim($className, '\\'))[0]) . DIRECTORY_SEPARATOR : $this->rootNs;
+		$rootNs = is_null($this->rootNs) ? explode('\\', rtrim($className, '\\'))[0] . DIRECTORY_SEPARATOR : $this->rootNs;
 
-
-		if (file_exists($this->libraryDir . DIRECTORY_SEPARATOR . strtolower($rootNs) . 'autoload.json')) {
+		if (file_exists($this->libraryDir . DIRECTORY_SEPARATOR . $rootNs . 'autoload.json')) {
 
 			$json = json_decode(file_get_contents($this->libraryDir . DIRECTORY_SEPARATOR . $rootNs . 'autoload.json'));
-	
+
 			if (isset($json->include)) 	foreach ($json->include as $file) require_once $this->libraryDir . DIRECTORY_SEPARATOR . $rootNs . $file;
-	
+
 			foreach ($json->modules as $key => $value) 	{
 				if ($key == 'Axel\\Module\\PSR0') {
 					$value[0] = $this->libraryDir . DIRECTORY_SEPARATOR . $rootNs . $value[0];

--- a/module/Library.php
+++ b/module/Library.php
@@ -3,27 +3,30 @@ namespace Axel\Module;
 class Library implements \Autoload\Module {
 	private $libraryDir;
 	private $axel;
+	private $rootNs;
 	private $cwd;
 		
-	public function __construct(\Axel\Axel $axel, $libraryDir) {
+	public function __construct(\Axel\Axel $axel, $libraryDir, $rootNs = null, $baseDir = null) {
 		$this->axel = $axel;
-		$this->libraryDir = getcwd() . DIRECTORY_SEPARATOR . str_replace('./', '', $libraryDir);
+		$this->cwd = is_null($baseDir) ? getcwd() : $baseDir;
+		$this->libraryDir = $this->cwd . DIRECTORY_SEPARATOR . str_replace('./', '', $libraryDir);
+		$this->rootNs = $rootNs;
 	}
 	
 	public function locate($className) {
 
-		$rootNs = strtolower(explode('\\', rtrim($className, '\\'))[0]);
+		$rootNs = is_null($this->rootNs) ? strtolower(explode('\\', rtrim($className, '\\'))[0]) . DIRECTORY_SEPARATOR : $this->rootNs;
 
 
-		if (file_exists($this->libraryDir . DIRECTORY_SEPARATOR . strtolower($rootNs) . DIRECTORY_SEPARATOR . 'autoload.json')) {
+		if (file_exists($this->libraryDir . DIRECTORY_SEPARATOR . strtolower($rootNs) . 'autoload.json')) {
 
-			$json = json_decode(file_get_contents($this->libraryDir . DIRECTORY_SEPARATOR . $rootNs . DIRECTORY_SEPARATOR . 'autoload.json'));
+			$json = json_decode(file_get_contents($this->libraryDir . DIRECTORY_SEPARATOR . $rootNs . 'autoload.json'));
 	
-			if (isset($json->include)) 	foreach ($json->include as $file) require_once $this->libaryDir . DIRECTORY_SEPARATOR . $rootNs . DIRECTORY_SEPARATOR . $file;
+			if (isset($json->include)) 	foreach ($json->include as $file) require_once $this->libraryDir . DIRECTORY_SEPARATOR . $rootNs . $file;
 	
 			foreach ($json->modules as $key => $value) 	{
 				if ($key == 'Axel\\Module\\PSR0') {
-					$value[0] = $this->libraryDir . DIRECTORY_SEPARATOR . $rootNs . DIRECTORY_SEPARATOR . $value[0];
+					$value[0] = $this->libraryDir . DIRECTORY_SEPARATOR . $rootNs . $value[0];
 				}
 				$module = new $key(...$value);
 				$this->axel->addModule($module);

--- a/module/PSR0.php
+++ b/module/PSR0.php
@@ -1,5 +1,4 @@
-
-<?php 
+<?php
 namespace Axel\Module;
 class PSR0 implements \Autoload\Module {
 	private $baseDir;


### PR DESCRIPTION
Leaving this here for review, mostly.

My use case, that prompted me to make these changes in my fork

The directory structure that I'm working with here is PSR-0-like, but not compatible with PSR-0, because it doesn't use the root namespace in any folders.  (Actually, it does use the root namespace in the project's root folder, but there are a couple of directories between the root folder and the folder where autoloaded classes reside.)

My directory structure:

- /bigdumbogre -- project root.  index.php lives here.
- /bigdumbogre/Resources -- web resources... images, scripts, stylesheets, etc.
- /bigdumbogre/Private -- protected by .htaccess.  Also contains `bootstrap.php` which I will include lower with my example of how to use 
- /bigdumbogre/Private/Classes -- root of autoloaded classes.  
- /bigdumbogre/Private/Foundation/Configuration -- place where configuration files reside.

So, because of the project's special needs, I have edited the \Axel\Module\Library class to be a bit more configurable, and maintaining backwards compatibility by making the new constructor arguments optional.

Here's `/bigdumbogre/Private/bootstrap.php`, as an example of how I'm using it.

    <?php

    $globalBasePath = __DIR__;

    require_once('Classes/External/Axel/axel.php');
    $axel = new \Axel\Axel;

    require_once('Classes/External/Dice/Dice.php');
    $dice = new \Dice\Dice();

    $axel->addModule(new \Axel\Module\PSR0('/Classes/External/Transphporm/src', '\\Transphporm'));
    $axel->addModule(new \Axel\Module\Library($axel, '/Classes/Foundation/Configuration', '', $globalBasePath));

    session_start();

`/bigdumbogre/Private/Classes/Configuration/autoload.json` for this project

    {
        "include": ["../Autoloader.php"],
        "modules": {
            "\\BigDumbOgre\\Foundation\\Autoloader": []
        }
    }

And `/bigdumbogre/index.php` that is able to get an arbitrary class

    <?php

    require_once('Private/bootstrap.php');

    $router = $dice->create('\\BigDumbOgre\\Foundation\\Router');